### PR TITLE
chore: fix build step

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "watch": "run-p -l -r watch:*",
     "watch:server": "nodemon -w src/server .",
     "watch:web": "webpack-dev-server --mode development --open --hot",
-    "build": "webpack --mode production",
+    "clean": "rm -rf build",
+    "build": "npm run clean && npm run build:web",
+    "build:web": "webpack --mode production",
     "coverage": "jest --coverage",
     "test": "jest"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,12 @@ const webpack = require('webpack')
 const HtmlWebPackPlugin = require('html-webpack-plugin')
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
 
+if (dotenv.error) {
+  // fallback to defaults, expecting all the neccessary vars are just set in ENV
+  const fallback = require('dotenv').config({ path: path.resolve(process.cwd(), '.env.defaults') })
+  if (!fallback.error) dotenv.parsed = fallback.parsed
+}
+
 const { PORT = 8000 } = process.env
 
 module.exports = {


### PR DESCRIPTION
If there's no `.env` file, then webpack should fallback to reading `.env.defaults` in order to provide list of accessible env vars. Proper values are expected to be set as regular ENV vars.